### PR TITLE
Fix #22; Setting nullglob for plugin installation loop

### DIFF
--- a/src/install_local_plugins.sh
+++ b/src/install_local_plugins.sh
@@ -5,10 +5,10 @@ if [ "$1" == '--help' ]; then
   exit 0
 fi
 
-for plugin in local/*; do
+$(shopt -s nullglob; for plugin in local/*; do
   echo installing $plugin
 
   cd $plugin
   python setup.py develop
   cd -
-done
+done)


### PR DESCRIPTION
Probably not the prettiest way to set the `nullglob` - but that way it's contained to the loop and won't leak into the user's console.

Other possibility would probably include getting the previous state, saving it into a variable, setting `nullglob`, executing the loop and then resetting to the saved state... But that seems even more cluttered.