### PR TITLE
Fix bug in statistics when there are no members

### DIFF
--- a/src/byro/members/stats.py
+++ b/src/byro/members/stats.py
@@ -15,7 +15,11 @@ def get_member_statistics():
     """
     Returns a list of tuples of the form ((year, month), joins, quits).
     """
-    date = Membership.objects.order_by('start').first().start
+    first_member = Membership.objects.order_by('start').first()
+    if not first_member:
+        return []
+
+    date = first_member.start
     end = Membership.objects.filter(end__isnull=False).order_by('-end').first().end
     result = []
 

--- a/src/tests/unit/test_member.py
+++ b/src/tests/unit/test_member.py
@@ -9,3 +9,13 @@ def test_profiles(member):
 
     assert len(profiles) > 1
     assert any([isinstance(profile, MemberProfile) for profile in profiles])
+
+
+@pytest.mark.django_db
+def test_stats_no_members():
+    from byro.members.stats import get_member_statistics
+
+    member_stats = get_member_statistics()
+
+    assert isinstance(member_stats, list)
+    assert len(member_stats) == 0


### PR DESCRIPTION
When getting started with byro I noticed this bug, so I fixed it.
Should be pretty straightforward.

Also adds a regression test.