### PR TITLE
Fix member statistics if no member ever left

### DIFF
--- a/src/byro/members/stats.py
+++ b/src/byro/members/stats.py
@@ -20,7 +20,10 @@ def get_member_statistics():
         return []
 
     date = first_member.start
-    end = Membership.objects.filter(end__isnull=False).order_by('-end').first().end
+    end_member = Membership.objects.filter(end__isnull=False).order_by('-end').first()
+    if not end_member:
+        return []
+    end = end_member.end
     result = []
 
     while date <= end:


### PR DESCRIPTION
The member statistics generated an "'NoneType' object has no attribute 'end'" exception if no member has ever left the organisation