### PR TITLE
Add shared SELinux label

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -9,7 +9,7 @@ web:
   links:
    - db
   volumes:
-   - .:/opt/code
+   - .:/opt/code:z
   ports:
    - "127.0.0.1:8020:8020"
 db:


### PR DESCRIPTION
With current Fedora (and probably other) as host system with activated and enforcing SELinux the docker quickstart introductions don't work. Symptom:

````
[henryk@localhost src]$ docker-compose run --rm web reset_db
python: can't open file './manage.py': [Errno 13] Permission denied
````
(and an AVC error is logged at the same time)

According to https://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/ the correct way to solve this issue is to add a volume (`:z` or `:Z`) option to re-label the volume content with a security label. I'm using `z` which uses a label shared between all containers (so that the running django web server container and one-off command containers can access the same volume).

**Open question**: Does this break for non-SELinux users?