### PR TITLE
Close #32: Add <title> tag to all core templates.

### DIFF
--- a/src/byro/common/templates/common/auth/login.html
+++ b/src/byro/common/templates/common/auth/login.html
@@ -1,8 +1,10 @@
 {% extends "office/base.html" %}
 {% load i18n %}
 
+{% block title %}{% trans "Login" %}{% endblock %}
+
 {% block headline %}
-Welcome to byro!
+{% trans "Welcome to byro!" %}
 {% endblock %}
 
 {% block content %}

--- a/src/byro/office/templates/office/account/add.html
+++ b/src/byro/office/templates/office/account/add.html
@@ -1,6 +1,8 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 {% load bootstrap4 %}
 {% load i18n %}
+
+{% block headline %}{% trans "Add Account …" %}{% endblock %}
 
 {% block content %}
 

--- a/src/byro/office/templates/office/account/base.html
+++ b/src/byro/office/templates/office/account/base.html
@@ -1,4 +1,4 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 {% load i18n %}
 
 {% block headline %}{% if account.name %}{{ account.name }}{% else %}{% trans "Default " %} {{ account.get_account_category_display }}{% endif %}{% endblock %}

--- a/src/byro/office/templates/office/account/list.html
+++ b/src/byro/office/templates/office/account/list.html
@@ -1,4 +1,4 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 
 {% load i18n %}
 

--- a/src/byro/office/templates/office/base_headline.html
+++ b/src/byro/office/templates/office/base_headline.html
@@ -1,0 +1,3 @@
+{% extends "office/base.html" %}
+
+{% block title %}{% block headline %}{% endblock %}{% endblock %}

--- a/src/byro/office/templates/office/dashboard.html
+++ b/src/byro/office/templates/office/dashboard.html
@@ -1,6 +1,8 @@
 {% extends "office/base.html" %}
 {% load i18n %}
 
+{% block title %}{% blocktrans %}Dashboard{% endblocktrans %}{% endblock %}
+
 {% block content %}
 
 <div class="dashboard-list">

--- a/src/byro/office/templates/office/mails/base.html
+++ b/src/byro/office/templates/office/mails/base.html
@@ -1,4 +1,4 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 {% load i18n %}
 
 {% block headline %}{% trans "Mails" %}{% endblock %}

--- a/src/byro/office/templates/office/mails/detail.html
+++ b/src/byro/office/templates/office/mails/detail.html
@@ -4,6 +4,8 @@
 {% load static %}
 {% load formset_tags %}
 
+{% block title %}{% trans "Mail" %} :: {{ block.super }}{% endblock %}
+
 {% block mail_content %}
 <form method='post'>
     {% csrf_token %}

--- a/src/byro/office/templates/office/mails/outbox.html
+++ b/src/byro/office/templates/office/mails/outbox.html
@@ -4,6 +4,8 @@
 {% load static %}
 {% load formset_tags %}
 
+{% block title %}{% trans "Outbox" %} :: {{ block.super }}{% endblock %}
+
 {% block mail_content %}
 <script type="text/javascript" src="{% static "js/jquery.formset.js" %}"></script>
 <div class="form-group row float-right">

--- a/src/byro/office/templates/office/mails/sent.html
+++ b/src/byro/office/templates/office/mails/sent.html
@@ -4,6 +4,8 @@
 {% load static %}
 {% load formset_tags %}
 
+{% block title %}{% trans "Sent Mails" %} :: {{ block.super }}{% endblock %}
+
 {% block mail_content %}
 <table class="table table-sm">
     <thead>

--- a/src/byro/office/templates/office/mails/template_detail.html
+++ b/src/byro/office/templates/office/mails/template_detail.html
@@ -4,6 +4,8 @@
 {% load static %}
 {% load formset_tags %}
 
+{% block title %}{% trans "Mail Template" %} :: {{ block.super }}{% endblock %}
+
 {% block mail_content %}
 <form method='post'>
     {% csrf_token %}

--- a/src/byro/office/templates/office/mails/templates.html
+++ b/src/byro/office/templates/office/mails/templates.html
@@ -4,6 +4,8 @@
 {% load static %}
 {% load formset_tags %}
 
+{% block title %}{% trans "Mail Templates" %} :: {{ block.super }}{% endblock %}
+
 {% block mail_content %}
 <div class="alert alert-info">
     {% blocktrans trimmed %}

--- a/src/byro/office/templates/office/member/add.html
+++ b/src/byro/office/templates/office/member/add.html
@@ -1,6 +1,8 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 {% load bootstrap4 %}
 {% load i18n %}
+
+{% block headline %}{% trans "Add Member …" %}{% endblock %}
 
 {% block content %}
 

--- a/src/byro/office/templates/office/member/base.html
+++ b/src/byro/office/templates/office/member/base.html
@@ -1,4 +1,4 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 {% load i18n %}
 
 {% block headline %}{{ member.name }} ({{ member.number }}){% endblock %}

--- a/src/byro/office/templates/office/member/dashboard.html
+++ b/src/byro/office/templates/office/member/dashboard.html
@@ -1,6 +1,8 @@
 {% extends "office/member/base.html" %}
 {% load i18n %}
 
+{% block title %}{{ block.super }} :: {% trans "Dashboard" %}{% endblock %}
+
 {% block member_content %}
 <div class="dashboard-list">
     <div class="dashboard-block {% if not is_active %}block-danger{% endif %}">

--- a/src/byro/office/templates/office/member/data.html
+++ b/src/byro/office/templates/office/member/data.html
@@ -2,6 +2,8 @@
 {% load bootstrap4 %}
 {% load i18n %}
 
+{% block title %}{{ block.super }} :: {% trans "Data" %}{% endblock %}
+
 {% block member_content %}
 
 <form method='post'>

--- a/src/byro/office/templates/office/member/finance.html
+++ b/src/byro/office/templates/office/member/finance.html
@@ -1,6 +1,8 @@
 {% extends "office/member/base.html" %}
 {% load i18n %}
 
+{% block title %}{{ block.super }} :: {% trans "Finance" %}{% endblock %}
+
 {% block member_content %}
 
 <table class="table table-sm">

--- a/src/byro/office/templates/office/member/list.html
+++ b/src/byro/office/templates/office/member/list.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% block title %}{% trans "Member List" %}{% endblock %}
+
 {% block content %}
 <p>
 <a href="{% url "office:members.add" %}" class="btn btn-success">

--- a/src/byro/office/templates/office/realtransaction/list.html
+++ b/src/byro/office/templates/office/realtransaction/list.html
@@ -1,8 +1,10 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 {% load i18n %}
 {% load bootstrap4 %}
 {% load static %}
 {% load formset_tags %}
+
+{% block headline %}{% trans "Real Transactions" %}{% endblock %}
 
 {% block content %}
 <script type="text/javascript" src="{% static "js/jquery.formset.js" %}"></script>

--- a/src/byro/office/templates/office/realtransaction/match.html
+++ b/src/byro/office/templates/office/realtransaction/match.html
@@ -1,11 +1,12 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 {% load i18n %}
 {% load bootstrap4 %}
 {% load static %}
 {% load formset_tags %}
 
+{% block headline %}{% trans "Match transactions" %}{% endblock %}
+
 {% block content %}
-<h3>{% trans "Match transactions" %}</h3>
 <script type="text/javascript" src="{% static "js/jquery.formset.js" %}"></script>
 <table class="table table-sm">
     <thead>

--- a/src/byro/office/templates/office/settings/base.html
+++ b/src/byro/office/templates/office/settings/base.html
@@ -1,4 +1,4 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 {% load i18n %}
 
 {% block headline %}Settings{% endblock %}

--- a/src/byro/office/templates/office/upload/add.html
+++ b/src/byro/office/templates/office/upload/add.html
@@ -1,8 +1,10 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 {% load i18n %}
 {% load bootstrap4 %}
 {% load static %}
 {% load formset_tags %}
+
+{% block headline %}{% trans "Upload Transaction …" %}{% endblock %}
 
 {% block content %}
 

--- a/src/byro/office/templates/office/upload/list.html
+++ b/src/byro/office/templates/office/upload/list.html
@@ -1,4 +1,4 @@
-{% extends "office/base.html" %}
+{% extends "office/base_headline.html" %}
 
 {% load i18n %}
 


### PR DESCRIPTION
New base template `office/base_headline.html` sets the `<title>` tag to the value of the `headline` block.
Templates can either:
  * `{% extends "office/base_headline.html" %}` and then fill `{% block headline %}{% trans "My Headline and Title" %}{% endblock %}`, or
  * `{% extends "office/base.html" %}` and then fill the `title` and `headline` blocks separately.

Closes byro/byro#32