### PR TITLE
Remove link to foreign domain

### DIFF
--- a/src/byro/office/templates/office/base.html
+++ b/src/byro/office/templates/office/base.html
@@ -104,7 +104,7 @@
                 {% endblock %}
             </div>
             <footer>
-                {% with "href='http://byro.org'" as a_attr %}
+                {% with "href='https://byro.readthedocs.io/'" as a_attr %}
                     {% blocktrans trimmed %}
                         powered by <a {{ a_attr }}>byro</a>
                     {% endblocktrans %}


### PR DESCRIPTION
We maybe shouldn't link every page of the project to a domain that doesn't belong to the project :)