### PR TITLE
run in development mode by default

### DIFF
--- a/src/byro/settings.py
+++ b/src/byro/settings.py
@@ -139,6 +139,12 @@ if os.getenv('TRAVIS'):
     DATABASES['default']['HOST'] = 'localhost'
     DATABASES['default']['PASSWORD'] = ''
 
+# for docker-compose development
+if os.getenv('DEVELOPMENT'):
+    DATABASES['default']['USER'] = 'byro'
+    DATABASES['default']['HOST'] = 'db'
+    DATABASES['default']['PASSWORD'] = 'byro'
+
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -4,13 +4,18 @@ web:
   environment:
       PYTHONUNBUFFERED: 0
       DJANGO_SETTINGS_MODULE: byro.settings
+      DEVELOPMENT: 1
   entrypoint:
-   - './manage.py'
+   - './src/manage.py'
   links:
    - db
   volumes:
-   - .:/opt/code
+   - ..:/opt/code/
   ports:
    - "127.0.0.1:8020:8020"
 db:
   image: postgres:10
+  environment:
+      POSTGRES_PASSWORD: byro
+      POSTGRES_DB: byro
+      POSTGRES_USER: byro


### PR DESCRIPTION
This PR changes `byro/settings.py` and `docker-compose.yml` to produce a working development environment by default.

Without the changes, these files need to be touched before being able to run `docker-compose` out of the box.