### PR TITLE
Fix missing bracket in membership due calculation

### DIFF
--- a/src/byro/members/models.py
+++ b/src/byro/members/models.py
@@ -573,7 +573,7 @@ class Membership(Auditable, models.Model, LogTargetMixin):
             try:
                 end = _now.replace(day=self.start.day).date()
             except ValueError:  # membership.start.day is not a valid date in our month, we'll use the last date instead
-                end = _now + relativedelta(day=1, months=1, days=-1).date()
+                end = (_now + relativedelta(day=1, months=1, days=-1)).date()
         date = self.start
         while date <= end:
             dues.add((date, self.amount))


### PR DESCRIPTION
Error trace:

ERROR 2020-02-24 00:39:41,938 django.request log Internal Server Error: /members/list
Traceback (most recent call last):
  File "/home/lemoer/tmp/byro/src/byro/members/models.py", line 574, in get_dues
    end = _now.replace(day=self.start.day).date()
ValueError: day is out of range for month

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/lemoer/tmp/byro/env/lib/python3.8/site-packages/Django-2.2.9-py3.8.egg/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/home/lemoer/tmp/byro/env/lib/python3.8/site-packages/Django-2.2.9-py3.8.egg/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/lemoer/tmp/byro/env/lib/python3.8/site-packages/Django-2.2.9-py3.8.egg/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/lemoer/tmp/byro/env/lib/python3.8/site-packages/Django-2.2.9-py3.8.egg/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/lemoer/tmp/byro/env/lib/python3.8/site-packages/Django-2.2.9-py3.8.egg/django/views/generic/base.py", line 97, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/lemoer/tmp/byro/src/byro/office/views/members.py", line 116, in post
    member.update_liabilites()
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/home/lemoer/tmp/byro/src/byro/members/models.py", line 428, in update_liabilites
    membership_range, membership_dues = membership.get_dues(_now=_now)
  File "/home/lemoer/tmp/byro/src/byro/members/models.py", line 576, in get_dues
    end = _now + relativedelta(day=1, months=1, days=-1).date()
AttributeError: 'relativedelta' object has no attribute 'date'