### PR TITLE
[RFC] [members] Allow "Account Balance" in CSV Import

### DIFF
--- a/src/byro/members/models.py
+++ b/src/byro/members/models.py
@@ -217,6 +217,16 @@ class Member(Auditable, models.Model, LogTargetMixin):
                 read_only=True,
             )
         )
+        result.append(
+            Field(
+                "_internal_last_transaction",
+                _("Last Member Fee Transaction Timestamp"),
+                "",
+                "last_membership_fee_transaction_timestamp",
+                computed=True,
+                read_only=True,
+            )
+        )
 
         reg_form = Configuration.get_solo().registration_form or []
         form_config = {entry["name"]: entry for entry in reg_form}
@@ -295,6 +305,20 @@ class Member(Auditable, models.Model, LogTargetMixin):
     @property
     def balance(self) -> Decimal:
         return self._calc_balance()
+
+    def _calc_last_membership_fee_transaction_timestamp(self):
+        _now = now()
+        fees_receivable_account = SpecialAccounts.fees_receivable
+        qs = Booking.objects.filter(
+            Q(debit_account=fees_receivable_account) | Q(credit_account=fees_receivable_account),
+            member=self,
+            transaction__value_datetime__lte=_now
+        )
+        return qs.aggregate(last_transaction=models.Max("transaction__value_datetime"))['last_transaction']
+
+    @property
+    def last_membership_fee_transaction_timestamp(self):
+        return self._calc_last_membership_fee_transaction_timestamp()
 
     def create_balance(self, start, end, commit=True, create_if_zero=True):
         if self.balances.exists():

--- a/src/byro/members/models.py
+++ b/src/byro/members/models.py
@@ -523,6 +523,33 @@ class Member(Auditable, models.Model, LogTargetMixin):
                 user_or_context="internal: update_liabilites, reverse stray liabilities",
             )
 
+    @transaction.atomic
+    def adjust_balance(self, user_or_context, memo, amount, from_, to_, value_datetime):
+        now_ = now()
+
+        if amount == 0:
+            return False
+
+        if amount < 0:
+            amount = -amount
+            from_, to_ = to_, from_
+
+        from_member = self if from_ == SpecialAccounts.fees_receivable else None
+        to_member = self if to_ == SpecialAccounts.fees_receivable else None
+
+        t = Transaction.objects.create(
+            value_datetime=value_datetime,
+            booking_datetime=now_,
+            user_or_context=user_or_context,
+            memo=memo,
+        )
+        t.debit(account=to_, member=to_member, amount=amount, user_or_context=user_or_context)
+        t.credit(
+            account=from_, member=from_member, amount=amount, user_or_context=user_or_context
+        )
+
+        return True
+
     def __str__(self):
         return "Member {self.number} ({self.name})".format(self=self)
 

--- a/src/byro/office/templates/office/member/dashboard.html
+++ b/src/byro/office/templates/office/member/dashboard.html
@@ -22,6 +22,10 @@
         </h1>
         <span class="dashboard-description">
             {% trans "current balance" %}
+            <br>
+            {% blocktrans with start=member.last_membership_fee_transaction_timestamp|date trimmed %}
+                Last transaction on {{ start }}.
+            {% endblocktrans %}
         </span>
     </div>
     {% if statute_barred_debt.in1year %}

--- a/src/byro/office/views/members.py
+++ b/src/byro/office/views/members.py
@@ -484,6 +484,9 @@ def default_csv_form_valid(view, form, dialect="excel"):
 
             do_update = False
             have_changes = False
+            create_initial_balance = False
+            initial_balance = None
+            initial_balance_timestamp = None
             for verb_name, field in mapping.items():
                 if field.field_id == "_internal_id":
                     member = Member.all_objects.filter(
@@ -514,19 +517,53 @@ def default_csv_form_valid(view, form, dialect="excel"):
                             field.setter(member, v)
                             have_changes = True
                     else:
-                        field.setter(member, v)
+                        if field.field_id == "_internal_balance":
+                            if dialect == csv_excel_de:
+                                v = v.replace('.', '').replace(',', '.')
+                            initial_balance = Decimal(v)
+                            if initial_balance != 0:
+                                create_initial_balance = True
+                        elif field.field_id == "_internal_last_transaction":
+                            if v != '' and v is not None:
+                                initial_balance_timestamp = dateparser.parse(v, languages=[settings.LANGUAGE_CODE, "en"])
+                                create_initial_balance = True
+                        else:
+                            field.setter(member, v)
 
             if do_update:
                 if have_changes:
                     member.log(view, ".updated")
                     member.save()
             else:
+                if create_initial_balance and not initial_balance_timestamp:
+                    messages.error(
+                        view.request,
+                        _("Either both or none columns has to be given: '{}' and '{}'").format(
+                            fields["_internal_balance"].name, fields["_internal_last_transaction"].name
+                        ),
+                    )
+                    return redirect(view.request.get_full_path())
+
                 member.log(view, ".created")
                 member.save()
 
                 # FIXME Changing membership when do_update is not implemented
                 if membership_parms:
                     create_membership(membership_parms, member)
+
+                if create_initial_balance:
+
+                    balance_changed = member.adjust_balance(
+                        view,
+                        "Initial Balance created by CSV Import",
+                        initial_balance,
+                        SpecialAccounts.fees_receivable,
+                        SpecialAccounts.opening_balance,
+                        initial_balance_timestamp
+                    )
+
+                    if balance_changed:
+                        member.log(view, ".finance.initial_balance", balance=member.balance)
 
     return redirect(reverse("office:members.list"))
 
@@ -985,7 +1022,6 @@ class MemberOperationsView(MultipleFormsMixin, MemberView):
         )
 
         member = self.get_member()
-        now_ = now()
 
         if form.cleaned_data["adjustment_type"] == "relative":
             amount = form.cleaned_data["amount"]
@@ -997,47 +1033,29 @@ class MemberOperationsView(MultipleFormsMixin, MemberView):
 
         amount_, from_, to_ = None, None, None
 
-        if amount != 0:
-            if form.cleaned_data["adjustment_reason"] == "initial":
-                amount_, from_, to_ = (
-                    amount,
-                    SpecialAccounts.opening_balance,
+        if form.cleaned_data["adjustment_reason"] == "initial":
+            from_, to_ = (
+                SpecialAccounts.opening_balance,
+                SpecialAccounts.fees_receivable,
+            )
+        elif form.cleaned_data["adjustment_reason"] == "waiver":
+            if amount < 0:
+                from_, to_ = (
                     SpecialAccounts.fees_receivable,
+                    SpecialAccounts.lost_income,
                 )
-            elif form.cleaned_data["adjustment_reason"] == "waiver":
-                if amount < 0:
-                    amount_, from_, to_ = (
-                        -amount,
-                        SpecialAccounts.fees_receivable,
-                        SpecialAccounts.lost_income,
-                    )
-                else:
-                    messages.error(
-                        self.request,
-                        _(
-                            "Fee waiving needs to decrease debts. Use a negative value in relative mode, or a value higher than the current one in absolute mode."
-                        ),
-                    )
-                    return
+            elif amount > 0:
+                messages.error(
+                    self.request,
+                    _(
+                        "Fee waiving needs to decrease debts. Use a negative value in relative mode, or a value higher than the current one in absolute mode."
+                    ),
+                )
+                return
 
-            if amount_ < 0:
-                amount_ = -amount_
-                from_, to_ = to_, from_
+        balance_changed = member.adjust_balance(self, memo, amount, from_, to_, form.cleaned_data["date"])
 
-            from_member = member if from_ == SpecialAccounts.fees_receivable else None
-            to_member = member if to_ == SpecialAccounts.fees_receivable else None
-
-            t = Transaction.objects.create(
-                value_datetime=form.cleaned_data["date"],
-                booking_datetime=now_,
-                user_or_context=self,
-                memo=memo,
-            )
-            t.debit(account=to_, member=to_member, amount=amount_, user_or_context=self)
-            t.credit(
-                account=from_, member=from_member, amount=amount_, user_or_context=self
-            )
-
+        if balance_changed:
             balance = member.balance
 
             if form.cleaned_data["adjustment_reason"] == "initial":


### PR DESCRIPTION
This enables two new workflows:
1. It allows to export the *Members* from one byro instance to and import them to another byro instance while their balances are migrated.
2. It allows mirgrations migrating *Members* from from other tools like e.g. JVerein while keeping the account balance.

What do you think? Suggestions and ideas welcome.