### PR TITLE
Add scripts to deploy via docker container

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,10 @@ is still a work in progress, it is already usable and in active use.
 
 .. image:: docs/img/screenshots/office_dashboard.png
 
-Development Setup
+Development and Production Setup
 -----------------
 
-Please refer to the `installation documentation`_.
+Please refer to the `development`_ or the `production documentation`_.
 
 Features
 --------
@@ -60,7 +60,8 @@ GitHub. You can see all byro plugins on GitHub `here`_.
 .. |byro| image:: docs/img/logo/byro_128.png
    :alt: byro
 .. _developer documentation: http://byro.readthedocs.io/en/latest/
-.. _installation documentation: https://byro.readthedocs.io/en/latest/developer/setup/
+.. _administrator documentation: https://byro.readthedocs.io/en/latest/administrator/
+.. _development: https://byro.readthedocs.io/en/latest/developer/setup/
 .. _byro: https://byro.cloud
 .. _here: https://github.com/topics/byro-plugin
 .. _byro-mailman: https://github.com/byro/byro-mailman

--- a/docs/administrator/docker-compose.rst
+++ b/docs/administrator/docker-compose.rst
@@ -1,5 +1,5 @@
 Installation via docker-compose
-=============================
+===============================
 
 In the folder `production/` of the byro repository, you can find setup scripts
 and a `docker-compose.yml`, which will help you set up a production deployment of byro using docker.
@@ -20,10 +20,10 @@ This guide assumes that you have installed and set up the following system servi
 Step 1: Configuration
 ---------------------
 
-Checkout the repository, and run the setup script:
+Checkout the repository, and run the setup script::
 
-  # git clone https://github.com/byro/byro
-  # byro/production/setup.sh
+    # git clone https://github.com/byro/byro
+    # byro/production/setup.shß
 
 This will create a folder `byro-data/` next to the byro folder, which will
 contain all your data.
@@ -45,25 +45,25 @@ Open this file in an editor, and configure the following aspects:
           information.
 
 Step 2: Deployment
---------------------
+------------------
 
-After you have changed your configuration, run the setup script again:
+After you have changed your configuration, run the setup script again::
 
-  # byro/production/setup.sh
+    # byro/production/setup.sh
 
 Your database will now be created, and you will be prompted to create a superuser.
 After that, your deployment will be complete. You can use the `setup.sh` script
-to perform additional tasks, such as stopping your deployment, tailing the logs,
+to perform further tasks, such as stopping your deployment, tailing the logs,
 or installing byro plugins.
 
-For more information, run
+For more information, run::
 
-  # byro/production/setup.sh help
+    # byro/production/setup.sh help
 
 Step 3: Install the FinTS plugin (optional)
 -------------------------------------------
 
-The following call will install the `byro-fints plugin`_. 
+The following call will install the `byro-fints plugin`_::
 
   # byro/production/setup.sh fints
 

--- a/docs/administrator/docker-compose.rst
+++ b/docs/administrator/docker-compose.rst
@@ -1,0 +1,72 @@
+Installation via docker-compose
+=============================
+
+In the folder `production/` of the byro repository, you can find setup scripts
+and a `docker-compose.yml`, which will help you set up a production deployment of byro using docker.
+
+.. note:: There is also a `docker-compose` file inside the `src/` folder.
+          This file is only intended for development!
+
+Step 0: Prerequisites
+---------------------
+
+This guide assumes that you have installed and set up the following system services:
+
+* Docker
+* docker-compose
+* An SMTP server to send out mails
+* An HTTP reverse proxy, e.g. `nginx`_ or Apache to allow HTTPS connections
+
+Step 1: Configuration
+---------------------
+
+Checkout the repository, and run the setup script:
+
+  # git clone https://github.com/byro/byro
+  # byro/production/setup.sh
+
+This will create a folder `byro-data/` next to the byro folder, which will
+contain all your data.
+It will also copy an initial `byro.cfg` to the data folder.
+
+Open this file in an editor, and configure the following aspects:
+
+`[mail]`
+    Enter connection settings to your SMTP server. The pre-filled IP represents the
+    address the docker container can use to reach your host box. Change this if your
+    SMTP server is not local to the server running byro.
+
+`[site]`
+    Change the URL to an URL your server is reachable on. If your server is not yet
+    exposed to the world, you will need to enable `debug` to bypass Django URL security.
+
+.. note:: Never expose your server to the world with `debug = True` enabled.
+          This will allow users accessing the page to view potentially sensitive
+          information.
+
+Step 2: Deployment
+--------------------
+
+After you have changed your configuration, run the setup script again:
+
+  # byro/production/setup.sh
+
+Your database will now be created, and you will be prompted to create a superuser.
+After that, your deployment will be complete. You can use the `setup.sh` script
+to perform additional tasks, such as stopping your deployment, tailing the logs,
+or installing byro plugins.
+
+For more information, run
+
+  # byro/production/setup.sh help
+
+Step 3: Install the FinTS plugin (optional)
+-------------------------------------------
+
+The following call will install the `byro-fints plugin`_. 
+
+  # byro/production/setup.sh fints
+
+
+.. _nginx: https://botleg.com/stories/https-with-lets-encrypt-and-nginx/
+.. _byro-fints plugin: https://github.com/henryk/byro-fints

--- a/docs/administrator/index.rst
+++ b/docs/administrator/index.rst
@@ -18,3 +18,4 @@ on administrative basics like securing your server, or performing backups.
 
    installation
    configuration
+   docker-compose

--- a/docs/administrator/installation.rst
+++ b/docs/administrator/installation.rst
@@ -4,6 +4,8 @@ Installation
 This guide will help you to install byro on a Linux distribution, as long as
 the prerequisites are present.
 
+Note: there is also an experimental deployment available via `docker-compose`_.
+
 Step 0: Prerequisites
 ---------------------
 
@@ -229,4 +231,4 @@ If you want to upgrade byro to a specific release, you can substitute
 .. _PostgreSQL: https://www.digitalocean.com/community/tutorials/how-to-install-and-use-postgresql-9-4-on-debian-8
 .. _ufw: https://en.wikipedia.org/wiki/Uncomplicated_Firewall
 .. _strong encryption settings: https://mozilla.github.io/server-side-tls/ssl-config-generator/
-
+.. _docker-compose: https://byro.readthedocs.io/en/latest/administrator/docker-compose/

--- a/docs/administrator/installation.rst
+++ b/docs/administrator/installation.rst
@@ -205,7 +205,7 @@ Next Steps: Updates
 
 .. warning:: While we try hard not to issue breaking updates, **please perform a backup before every upgrade**.
 
-To upgrade byro, please first read through our :ref:`changelog` and if
+To upgrade byro, please first read through our changelog and if
 available our release blog post to check for relevant update notes. Also, make
 sure you have a current backup.
 

--- a/production/byro.example.cfg
+++ b/production/byro.example.cfg
@@ -1,0 +1,25 @@
+[filesystem]
+data = /var/byro/data
+media = /var/byro/data/media
+logs = /var/byro/data/logs
+
+[site]
+debug = False
+url = http://byro.mydomain.com
+
+[database]
+name = byro
+user = byro
+password = byro
+host = db
+port = 5432
+
+[mail]
+from = admin@byro
+# by default, this is the IP address of your docker host, as seen from byro
+host = MAIL_HOST
+port = 25
+user = admin
+password = something
+tls = False
+ssl = True

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -1,0 +1,70 @@
+version: "2.1"
+
+services:
+  manage:
+    build: ../src/
+    user: uid1000
+    environment:
+        PYTHONUNBUFFERED: 1
+        DJANGO_SETTINGS_MODULE: byro.settings
+        DEVELOPMENT: 0
+    entrypoint: ['python', '-m', 'byro']
+    command: "help"
+    volumes:
+      - ../../byro-data/byro.cfg:/byro/byro.cfg:rw
+      - ../../byro-data/data:/var/byro/data
+      - ../../byro-data/static.dist:/byro/static.dist:rw
+    restart: "no"
+
+  gunicorn:
+    build: ../src/
+    user: uid1000
+    environment:
+        PYTHONUNBUFFERED: 1
+        DJANGO_SETTINGS_MODULE: byro.settings
+        DEVELOPMENT: 0
+    working_dir: '/byro'
+    entrypoint:
+      - 'gunicorn'
+    command: >
+      byro.wsgi --name byro --workers 4
+      --max-requests 1200 --max-requests-jitter 50
+      --log-level=info
+      --bind=0.0.0.0:8345
+    links:
+      - db
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - ../../byro-data/byro.cfg:/byro/byro.cfg:ro
+      - ../../byro-data/data:/var/byro/data
+      - ../../byro-data/static.dist:/byro/static.dist:rw
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:stable-alpine
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ../../byro-data/data/media:/var/byro/data/media:ro
+      - ../../byro-data/static.dist:/var/byro/static.dist:ro
+    links:
+      - gunicorn
+    restart: unless-stopped
+    ports:
+      - 8345:80
+
+  db:
+    image: postgres:10-alpine
+    environment:
+        POSTGRES_PASSWORD: byro
+        POSTGRES_DB: byro
+        POSTGRES_USER: byro
+    volumes:
+      - ../../byro-data/db/:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/production/nginx.conf
+++ b/production/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80 default_server;
+
+    add_header Referrer-Options same-origin;
+    add_header X-Content-Type-Options nosniff;
+
+    location / {
+        proxy_pass http://gunicorn:8345/;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Host $http_host;
+    }
+
+    location /media/ {
+        alias /var/byro/data/media/;
+        add_header Content-Disposition 'attachment; filename="$1"';
+        expires 7d;
+        access_log off;
+    }
+
+    location /static/ {
+        alias /var/byro/static.dist/;
+        access_log off;
+        expires 365d;
+        add_header Cache-Control "public";
+    }
+}

--- a/production/setup.sh
+++ b/production/setup.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR"
+
+mkdirs() {
+    mkdir -p "$DATA/data"
+    mkdir -p "$DATA/static.dist"
+}
+
+DATA="$DIR/../../byro-data"
+mkdirs
+DATA="$(cd "$DATA" && pwd)"
+
+CONFIG="$DATA/byro.cfg"
+
+COMPLETE_MIGRATE="$DATA/.completed_migrate"
+COMPLETE_REBUILD="$DATA/.completed_rebuild"
+COMPLETE_SUPERUSER="$DATA/.completed_superuser"
+COMPOSE=(docker-compose -p byro)
+
+stop() {
+    "${COMPOSE[@]}" down -v
+}
+
+create_config() {
+    stop
+
+    cat <<EOF
+=== Welcome ===
+This will setup a byro production deployment using docker.
+
+Your data will end up in $DATA.
+Make sure to setup backups for everything in that folder.
+
+Firstly, we will create a configuration.
+An example config will be created at $CONFIG.
+
+Please, edit that config file to your likings and re-run this script to continue.
+If you want to start over, simply delete the data folder, and re-run this script.
+EOF
+    cp "$DIR/byro.example.cfg" "$CONFIG"
+    
+    start_db
+    IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' byro_db_1)"
+    sed -i "s/MAIL_HOST/$IP/" "$CONFIG"
+}
+
+start_db() {
+    echo "Starting database in background..."
+    "${COMPOSE[@]}" up -d db
+}
+
+start_migrate() {
+    echo "Performing migrations..."
+    "${COMPOSE[@]}" run manage migrate
+    touch "$COMPLETE_MIGRATE"
+
+    start_rebuild
+}
+
+start_rebuild() {
+     echo "Running rebuild..."
+    "${COMPOSE[@]}" run manage collectstatic
+    touch "$COMPLETE_REBUILD"
+    
+    start_superuser
+}
+
+start_superuser () {
+    cat <<EOF
+Creating superuser...
+===
+You will be prompted for an email address, and a password.
+Please choose your password to be secure and do not forget it.
+===
+EOF
+    "${COMPOSE[@]}" run manage createsuperuser --username admin
+    
+    touch "$COMPLETE_SUPERUSER"
+    start
+}
+
+start() {
+    "${COMPOSE[@]}" up -d db gunicorn nginx
+    
+    cat <<EOF
+All done!
+Your software should now be running at this URL:
+http://127.0.0.1:8345/
+
+If you want to expose that to the world, make sure to disable "Debug" in the config and put an SSL certificate on it!
+EOF
+}
+
+
+case "$*" in
+
+stop)
+    stop
+    ;;
+help|--help|-h|h)
+    cat <<EOF
+Usage:
+    ./setup.sh          Run setup
+    ./setup.sh stop     Stop running services
+EOF
+    ;;
+"")
+    if [[ ! -f "$CONFIG" ]]; then
+        create_config
+    elif [[ ! -f "$COMPLETE_MIGRATE" ]]; then
+        start_db
+        start_migrate
+    elif [[ ! -f "$COMPLETE_REBUILD" ]]; then
+        start_db
+        start_rebuild
+    elif [[ ! -f "$COMPLETE_SUPERUSER" ]]; then
+        start_db
+        start_superuser
+    else
+        start
+    fi
+    ;;
+esac

--- a/production/setup.sh
+++ b/production/setup.sh
@@ -86,7 +86,7 @@ All done!
 Your software should now be running at this URL:
 http://127.0.0.1:8345/
 
-If you want to expose that to the world, make sure to disable "Debug" in the config and put an SSL certificate on it!
+If you want to expose that to the world, make sure to disable "Debug" in the config and put a TLS certificate on it!
 EOF
 }
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /byro && chown uid1000: /byro
 
 ADD . /byro
 ADD byro.docker.cfg /byro/byro.cfg
-RUN cd /byro && pip3 install -e .
+RUN cd /byro && pip3 install -e . && pip3 install gunicorn
 RUN cd /byro && /bin/zsh install_local_plugins.sh
 
 CMD ["runserver", "0.0.0.0:8020"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,7 +4,9 @@ MAINTAINER byro team
 EXPOSE 8020
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y zsh gettext libjpeg-dev libmagic-dev
+RUN apt-get update && \
+    apt-get install -y zsh gettext libjpeg-dev libmagic-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN useradd uid1000 -d /home/uid1000
 RUN mkdir -p /home/uid1000 && chown uid1000: /home/uid1000


### PR DESCRIPTION
This (only lightly tested) adds a folder `production/` which contains:

- nginx configs
- docker-compose file for production deployment (for now, behind another reverse proxy to do SSL) to make integration easier
- a script `setup.sh` which brings together all of the above

Also, add `gunicorn` to the base development docker image to make life a little bit easier.

Feel free to throw this away or rewrite it completely, I just thought it might be helpful to upstream :) .

```
Usage:
    production/setup.sh          Run setup
    production/setup.sh stop     Stop running services
    production/setup.sh logs     Tail the logs
    production/setup.sh plugin <git-url>
                install a plugin from a git url
    production/setup.sh fints    install the byron-fints plugin
```