### PR TITLE
Fix missing attribute `transactions` on RealTransactionSource

### DIFF
--- a/src/byro/bookkeeping/models/real_transaction.py
+++ b/src/byro/bookkeeping/models/real_transaction.py
@@ -65,9 +65,7 @@ class RealTransactionSource(Auditable, models.Model, LogTargetMixin):
         self.save()
         return response
 
-
     @property
     def transactions(self):
-        """Get all transactions"""
+        """Get all transactions."""
         return Transaction.objects.filter(bookings__source=self)
-

--- a/src/byro/bookkeeping/models/real_transaction.py
+++ b/src/byro/bookkeeping/models/real_transaction.py
@@ -64,3 +64,23 @@ class RealTransactionSource(Auditable, models.Model, LogTargetMixin):
         self.state = SourceState.PROCESSED
         self.save()
         return response
+
+    @property
+    def transactions(self):
+        """Get all transactions"""
+        return TransactionSet(self)
+
+
+class TransactionSet:
+    """
+    This is a pseudo related manager, providing a minimal
+    implementation for `all()`.
+    """
+    def __init__(self, source):
+        """Set real transaction source"""
+        self.source = source
+
+    def all(self):
+        """Get all transactions via bookings"""
+        return (b.transaction for b in self.source.bookings.all())
+

--- a/src/byro/bookkeeping/models/real_transaction.py
+++ b/src/byro/bookkeeping/models/real_transaction.py
@@ -65,22 +65,9 @@ class RealTransactionSource(Auditable, models.Model, LogTargetMixin):
         self.save()
         return response
 
+
     @property
     def transactions(self):
         """Get all transactions"""
-        return TransactionSet(self)
-
-
-class TransactionSet:
-    """
-    This is a pseudo related manager, providing a minimal
-    implementation for `all()`.
-    """
-    def __init__(self, source):
-        """Set real transaction source"""
-        self.source = source
-
-    def all(self):
-        """Get all transactions via bookings"""
-        return (b.transaction for b in self.source.bookings.all())
+        return Transaction.objects.filter(bookings__source=self)
 


### PR DESCRIPTION
Hi,

the RealTransactionSource model is missing the transactions attribute. (Which most likely was a RelatedManager at some point.)

The error occured when uploading a bank CSV import with a working CSV parser plugin.