### PR TITLE
[RFC] Per asset account balances

### DIFF
--- a/src/byro/bookkeeping/models/account.py
+++ b/src/byro/bookkeeping/models/account.py
@@ -43,10 +43,7 @@ class AccountTag(models.Model):
 
 class AccountQuerySet(models.QuerySet):
 
-    def with_balance(self): #, transaction_qs):
-
-        only_consider_account_id = 3
-
+    def with_balance(self, only_consider_account_id=None):
         # This query is a bit complex:
         #
         # 1. We rely on the fact, that a transaction can only have either

--- a/src/byro/bookkeeping/models/account.py
+++ b/src/byro/bookkeeping/models/account.py
@@ -1,12 +1,13 @@
 from decimal import Decimal
 
 from django.db import models
-from django.db.models import Q
+from django.db.models import Q, OuterRef, Subquery, Value
 from django.urls import reverse
 from django.utils.decorators import classproperty
 from django.utils.safestring import mark_safe
 from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
+from django.apps import apps
 
 from byro.common.models import LogTargetMixin
 from byro.common.models.auditable import Auditable
@@ -40,7 +41,103 @@ class AccountTag(models.Model):
         return self.name
 
 
+class AccountQuerySet(models.QuerySet):
+
+    def with_balance(self): #, transaction_qs):
+
+        only_consider_account_id = 3
+
+        # This query is a bit complex:
+        #
+        # 1. We rely on the fact, that a transaction can only have either
+        #    multiple debit bookings or multiple credit bookings but not both.
+        #    This is a general nececity for the database scheme to have
+        #    unambigious cash flow.
+        #
+        # 2. First, we select all transactions and join the coresponding bookings,
+        #    so we get something like this:
+        #
+        #     transaction_id  | debit_account_id | credit_account_id | amount
+        #    -----------------+------------------+-------------------+--------
+        #                  1  |               10 |                15 | 100.00
+        #                  1  |               12 |                15 |  20.00
+        #                  2  |             .... |               ... |    ...
+        #
+        #    Note: Even through transaction 1 corresponds to a single credit
+        #    booking row of 120.00 € for account 15 in the database, this credit
+        #    booking is splitted here into two rows. These credit parts are then
+        #    joined with the debit bookings, so every row corresponds to one
+        #    "cash flow" from credit_account_id to debit_account_id. This
+        #    happens for all split transactions in both directions (splitted
+        #    debits and splitted credits).
+        #
+        # 3. To obtain the correct amount for the cash flow, the lower amount of
+        #    both sides (debit and credit) is taken. This works under the
+        #    premise 1.
+        #
+        # 4. To filter for cash flows which include a certain account
+        #    only_consider_account_id, the WHERE clause
+        #    "(%s in (C.credit_account_id, D.debit_account_id) OR %s)" is
+        #    introduced. The second variable %s is used to bypass the first
+        #    clause if all all accounts should be considered. This case
+        #    is associated with only_consider_account_id = None.
+        #
+        # 5. As we do not want to include unbalanced transactions, there is
+        #    another part in the where clause, which makes sure, that both
+        #    credit_account_id and dedit_account_id are not NULL for all
+        #    selected rows.
+        #
+        # 6. As we are only interested in the accumulated cash flows, the
+        #    GROUP BY statement merges the transactions per (debit, credit)
+        #    account pair. This result is made available as CTE to the accounts
+        #    query via the name "cash_flows".
+        #
+        # 7. The actual select statement for the accounts uses subqueries to
+        #    the CTE result to obtain the balances.
+
+        q = """
+        WITH cash_flows AS (
+            SELECT
+                D.debit_account_id,
+                C.credit_account_id,
+                Sum(CASE
+                      WHEN C.amount < D.amount OR D.amount IS NULL THEN C.amount
+                      ELSE D.amount
+                    END) AS amount
+            FROM   "bookkeeping_transaction"
+                LEFT OUTER JOIN "bookkeeping_booking" D
+                             ON ( D."transaction_id" = "bookkeeping_transaction"."id"
+                                  AND D."debit_account_id" IS NOT NULL )
+                LEFT OUTER JOIN "bookkeeping_booking" C
+                             ON ( C."transaction_id" = "bookkeeping_transaction"."id"
+                                  AND C."credit_account_id" IS NOT NULL )
+            WHERE
+                (%s in (C.credit_account_id, D.debit_account_id)
+                OR %s)
+                AND C.credit_account_id IS NOT NULL
+                AND D.debit_account_id IS NOT NULL
+            GROUP  BY C.credit_account_id,
+                   D.debit_account_id
+        )
+        SELECT
+            *,
+            (SELECT SUM(cash_flows.amount) as debit_amount
+            FROM cash_flows WHERE cash_flows.debit_account_id=id),
+            (SELECT SUM(cash_flows.amount) as credit_amount
+            FROM cash_flows WHERE cash_flows.credit_account_id=id)
+        FROM bookkeeping_account;"""
+
+        qs = self.raw(q, [only_consider_account_id, only_consider_account_id is None])
+
+        return qs
+
+class AccountManager(models.Manager):
+    def get_queryset(self):
+        return AccountQuerySet(self.model, using=self._db)
+
 class Account(Auditable, models.Model, LogTargetMixin):
+    objects = AccountManager()
+
     account_category = models.CharField(
         choices=AccountCategory.choices, max_length=AccountCategory.max_length
     )
@@ -54,6 +151,15 @@ class Account(Auditable, models.Model, LogTargetMixin):
         if self.name:
             return self.name
         return "{self.account_category} account #{self.id}".format(self=self)
+
+    @property
+    def net_amount(self):
+        net = None
+        if self.debit_amount is not None:
+            net = (net or 0) + self.debit_amount
+        if self.credit_amount is not None:
+            net = (net or 0) - self.credit_amount
+        return net
 
     @property
     def bookings(self):
@@ -85,15 +191,20 @@ class Account(Auditable, models.Model, LogTargetMixin):
             Q(bookings__debit_account=self) | Q(bookings__credit_account=self)
         )
 
-    def _filter_by_date(self, qs, start, end):
+    def _filter_by_date(self, qs, start, end, peer_account=None):
         if start:
             qs = qs.filter(value_datetime__gte=start)
         if end:
             qs = qs.filter(value_datetime__lte=end)
+        if peer_account is not None:
+            assert(peer_account != self)
+            qs = qs.filter(
+                Q(bookings__debit_account=peer_account) | Q(bookings__credit_account=peer_account)
+            )
         return qs
 
-    def balances(self, start=None, end=now()):
-        qs = self._filter_by_date(self.transactions, start, end)
+    def balances(self, start=None, end=now(), peer_account=None):
+        qs = self._filter_by_date(self.transactions, start, end, peer_account)
 
         result = qs.with_balances().aggregate(
             debit=models.functions.Coalesce(models.Sum("balances_debit"), 0),

--- a/src/byro/bookkeeping/models/transaction.py
+++ b/src/byro/bookkeeping/models/transaction.py
@@ -17,7 +17,8 @@ class TransactionQuerySet(models.QuerySet):
             balances_debit=models.Sum(
                 models.Case(
                     models.When(
-                        ~models.Q(bookings__debit_account=None), then="bookings__amount"
+                        ~models.Q(bookings__debit_account=None),
+                        then="bookings__amount"
                     ),
                     default=0,
                     output_field=models.DecimalField(max_digits=8, decimal_places=2),

--- a/src/byro/office/templates/office/account/list.html
+++ b/src/byro/office/templates/office/account/list.html
@@ -10,6 +10,21 @@
     <span class="fa fa-plus"></span> {% trans "Add new account" %}
 </a>
 </p>
+<p>
+<div class="form-group">
+    <form method="get" class="form form-inline">
+        <select name="asset_id_filter" class="form-control">
+            <option value="all" {% if "all" == request.GET.asset_id_filter %}selected{% endif %}>{% trans "All asset accounts" %}</option>
+            {% for account in accounts %}
+            {% if account.account_category == "asset" %}
+            <option value="{{ account.id }}" {% if account.id == request.GET.asset_id_filter|add:"0" %}selected{% endif %}>{{ account.name }}</option>
+            {% endif %}
+            {% endfor %}´
+        </select>
+        <button type="submit" class="btn btn-success">{% trans "Filter" %}</button>
+    </form>
+</div>
+</p>
 <table class="table table-sm">
     <thead>
         <tr>

--- a/src/byro/office/templates/office/account/list.html
+++ b/src/byro/office/templates/office/account/list.html
@@ -48,11 +48,9 @@
                         {{ account.get_account_category_display }}
                     {% endif %}
                 </a></td>
-                {% with balances=account.balances %}
-                <td class="text-md-right">{{ balances.debit|default:"" }}</td>
-                <td class="text-md-right">{{ balances.credit|default:"" }}</td>
-                <td class="text-md-right">{{ balances.net }}</td>
-                {% endwith %}
+                <td class="text-md-right">{{ account.debit_amount|default:"" }}</td>
+                <td class="text-md-right">{{ account.credit_amount|default:"" }}</td>
+                <td class="text-md-right">{{ account.net_amount|default:""}}</td>
             </tr>
         {% endfor %}
     </tbody>

--- a/src/byro/office/views/accounts.py
+++ b/src/byro/office/views/accounts.py
@@ -26,6 +26,16 @@ class AccountListView(ListView):
     context_object_name = "accounts"
     model = Account
 
+    def get_balance_params(self):
+        if self.request.GET.get("") == "unbalanced":
+            # TODO, FIXME: assert account id
+            return { 'peer_account' : 3 }
+
+    def get_queryset(self):
+        #transaction_qs = Transaction.objects.all()
+        qs = Account.objects.get_queryset().with_balance() # transaction_qs)
+        return qs
+
 
 class AccountCreateView(FormView):
     template_name = "office/account/add.html"

--- a/src/byro/office/views/accounts.py
+++ b/src/byro/office/views/accounts.py
@@ -33,7 +33,13 @@ class AccountListView(ListView):
 
     def get_queryset(self):
         #transaction_qs = Transaction.objects.all()
-        qs = Account.objects.get_queryset().with_balance() # transaction_qs)
+        only_consider_account_id = None
+
+        asset_id_filter = self.request.GET.get('asset_id_filter', "all")
+        if asset_id_filter != "all" and asset_id_filter.isnumeric():
+            only_consider_account_id = int(asset_id_filter)
+
+        qs = Account.objects.get_queryset().with_balance(only_consider_account_id)
         return qs
 
 


### PR DESCRIPTION
This is meant as an RFC and should be discussed.

The basic idea is, that while doing an EÜR for the Finanzamt, you are only interested in the cash flow with respect to your bank account(s). Purely virtual asset accounts as "Member fees receivable" or so are not interesting in this case.

To address this, I added a new filter to the accounts list, which allows to select a certain asset account. By default, this is set to "All asset accounts" and does not change anything:
![Screenshot from 2020-07-26 16-25-44](https://user-images.githubusercontent.com/601153/88481920-7c72df80-cf5e-11ea-90b8-6d6d2e34b5eb.png)

If you select an asset account in the dropdown, the following happens:

![Screenshot from 2020-07-26 16-25-59](https://user-images.githubusercontent.com/601153/88481916-77ae2b80-cf5e-11ea-998c-b5572229132d.png)

Some explanatory comments:
- The balances are calculated by only accounting bookings, which include the selected asset account.
- The result is still balanced.
- If cash flow between different asset accounts would exist, it would show up for both accounts. (This is expected behaviour, I would say. Otherwise the result wouldn't be balanced.)

As the underlying query became a bit complex, I made an extensive comment in the code. You can have a look, if you are interested in the details.

Questions, which could/should be discussed:
- What do you think about the idea?
- The underlying algorithm/query works not only for asset accounts, but for all accounts. As this suits my current use case, I just put the asset accounts as options in the dropdown. We could also opt to put all accounts here. Drawback would be, that the list becomes longer. Advantage would be, that users would be able to break down all account balances to counter accounts.

In general, this would make a big step towards generating a complete EÜR from byro. Or at least it would assist you a lot. I am curious about your comments.
