### PR TITLE
Fix migrations for members that only have a single name (e.g. "luto") as member name

### DIFF
--- a/src/byro/members/migrations/0012_split_names.py
+++ b/src/byro/members/migrations/0012_split_names.py
@@ -10,6 +10,8 @@ def rename(apps, schema_editor):
     for member in Member.objects.all():
         if member.name:
             name_parts = member.name.rsplit(maxsplit=1)
+            if len(name_parts) == 1:
+                name_parts = name_parts + name_parts
             member.direct_address_name = name_parts[0]
             member.order_name = name_parts[1]
             member.save()


### PR DESCRIPTION
Members, who have only one name without spaces (e.g. "luto" or "MacLemon") currently crash the `0012_split_names.py` migration. This fix uses the name for both required fields.