### PR TITLE
Account: add .debit_accounts and .credit_accounts

### DIFF
--- a/src/byro/bookkeeping/models/account.py
+++ b/src/byro/bookkeeping/models/account.py
@@ -78,6 +78,28 @@ class Account(Auditable, models.Model, LogTargetMixin):
         )
 
     @property
+    def credit_accounts(self):
+        from byro.bookkeeping.models import Booking
+
+        return Account.objects.filter(
+            id__in=Booking.objects.filter(
+                transaction__bookings__debit_account=self,
+                credit_account__isnull=False)
+            .values_list('credit_account',flat=True).distinct()
+        )
+
+    @property
+    def debit_accounts(self):
+        from byro.bookkeeping.models import Booking
+
+        return Account.objects.filter(
+            id__in=Booking.objects.filter(
+                transaction__bookings__credit_account=self,
+                debit_account__isnull=False)
+            .values_list('debit_account',flat=True).distinct()
+        )
+
+    @property
     def unbalanced_transactions(self):
         from byro.bookkeeping.models import Transaction
 


### PR DESCRIPTION
These attributes return accounts which have direct transactions
with the current account. This functions were initially created
while creating another PR, but they are not needed there anymore.
However, I think they will still be useful later e.g. to build
filters for account listings. Another usecase might be to build a
graph out of all accounts to visualize all used bookings.

Anyway, I am not sure, whether you will accept this as no
code currently uses this functions. As they are handy and I would
not want to loose the ideas and code, I submit this as PR.