### PR TITLE
docs: Added note about development dependencies

### DIFF
--- a/docs/developer/setup.rst
+++ b/docs/developer/setup.rst
@@ -70,6 +70,10 @@ The first thing you need are all the main application's dependencies::
     (env)$ cd src/
     (env)$ pip3 install -e .
 
+To be able to run the code checks and unit tests you need to install the development dependencies as well::
+
+    (env)$ pip3 install -e ".[dev]"
+
 .. note:: Under Windows, if you get the error message ``failed to find libmagic.  Check your installation`` error, do ``pip install python-magic-bin`` in the virtual environment to install the necessary magic library for Windows.
 
 .. note:: Under macOS, if you get the error message ``failed to find libmagic.  Check your installation``, do ``brew install libmagic`` to install the necessary magic library.


### PR DESCRIPTION
To run the tests and code checks we have to install the needed tools.
This isn't mentioned in the developer documentation, yet

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>