### PR TITLE
dependencies: Updated a lot of modules

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -66,30 +66,30 @@ setup(
     keywords="members membership fees club group clubs associations association",
     install_requires=[
         "canonicaljson==1.5.0",  # https://github.com/matrix-org/python-canonicaljson/blob/master/CHANGES.md
-        "chardet~=3.0.0",  # https://github.com/chardet/chardet/releases
-        "celery~=4.4.0",  # search for "what's new" on http://docs.celeryproject.org/en/latest/
-        "csscompressor~=0.9.0",  # 2017-11, no changelog, https://github.com/sprymix/csscompressor
-        "dateparser>=0.7,<1.2",  # https://github.com/scrapinghub/dateparser/blob/master/HISTORY.rst
-        "Django~=3.1.0",  # https://docs.djangoproject.com/en/2.0/releases/
+        "chardet>=4.0,<4.1",  # https://github.com/chardet/chardet/releases
+        "celery>=5.1,<6.0",  # search for "what's new" on http://docs.celeryproject.org/en/latest/
+        "csscompressor~=0.9.5",  # 2017-11, no changelog, https://github.com/sprymix/csscompressor
+        "dateparser>=1.1,<1.2",  # https://github.com/scrapinghub/dateparser/blob/master/HISTORY.rst
+        "Django>=3.1,<3.2",  # https://docs.djangoproject.com/en/2.0/releases/
         "django-annoying~=0.10.0",  # https://github.com/skorokithakis/django-annoying/releases
-        "django-bootstrap4~=2.2.0",  # http://django-bootstrap4.readthedocs.io/en/latest/history.html
+        "django-bootstrap4>=3.0,<3.1",  # http://django-bootstrap4.readthedocs.io/en/latest/history.html
         "django-compressor~=2.4.0",  # https://django-compressor.readthedocs.io/en/latest/changelog/
-        "django-extensions~=3.0.0",  # https://github.com/django-extensions/django-extensions/blob/master/CHANGELOG.md
+        "django-extensions>=3.1,<3.2",  # https://github.com/django-extensions/django-extensions/blob/master/CHANGELOG.md
         "django-formset-js-improved==0.5.0.2",  # no changelog, https://github.com/pretix/django-formset-js
-        "django-i18nfield~=1.8.0",  # 2017-11, no changelog, https://github.com/raphaelm/django-i18nfield/
+        "django-i18nfield>=1.8.7,<1.10",  # 2017-11, no changelog, https://github.com/raphaelm/django-i18nfield/
         "django-libsass>=0.8,<0.10",  # inactive, https://github.com/torchbox/django-libsass/blob/master/CHANGELOG.txt
         "django-localflavor>=3.0,<3.2",
-        "django-select2~=7.4.0",  # https://github.com/applegrew/django-select2/releases
-        "django-solo~=1.1.0",  # https://github.com/lazybird/django-solo/blob/master/CHANGES
+        "django-select2>=7.7,<7.8",  # https://github.com/applegrew/django-select2/releases
+        "django-solo>=1.2.0,<1.3",  # https://github.com/lazybird/django-solo/blob/master/CHANGES
         "inlinestyler~=0.2",  # https://github.com/dlanger/inlinestyler/blob/master/CHANGELOG
         "jinja2>=2.10.1",  # https://github.com/pallets/jinja/blob/master/CHANGES.rst
         "psycopg2-binary",
         "python-dateutil",
         "python-magic~=0.4.0",
         "pynacl~=1.4.0",  # https://github.com/pyca/pynacl/blob/master/CHANGELOG.rst
-        "qrcode[pil]==6.1",  # https://github.com/lincolnloop/python-qrcode/blob/master/CHANGES.rst
+        "qrcode[pil]>=7.3,<7.4",  # https://github.com/lincolnloop/python-qrcode/blob/master/CHANGES.rst
         "unicodecsv~=0.14.0",
-        "more-itertools>=8.4,<8.11",
+        "more-itertools>=8.10,<8.11",
         "schwifty==2021.10.2",
     ],
     extras_require={


### PR DESCRIPTION
This updates all the dependencies that have been notified by dependabot,
since the PRs don't really work anymore (dependabot-preview has been discontinued).
This closes #199 #198 #186 #182 #179 #178 #175 #174 #169 #166 #164 #161

Signed-off-by: Nis Wechselberg <enbewe@enbewe.de>

I tested this with unit tests and sample data and it looks fine. 