### PR TITLE
Fixed git branch name in installation guide

### DIFF
--- a/docs/administrator/installation.rst
+++ b/docs/administrator/installation.rst
@@ -94,7 +94,7 @@ Next, we will install byro – you can either install the latest PyPI release, o
 branch or commit::
 
     $ pip install --user -U byro  # OR, alternatively
-    $ pip install --user -U "git+git://github.com/byro/byro.git@main#egg=byro&subdirectory=src"
+    $ pip install --user -U "git+git://github.com/byro/byro.git@master#egg=byro&subdirectory=src"
 
 We also need to create a data directory::
 


### PR DESCRIPTION
The branch is called `master` not `main`.

Results of the original command:

```
$ pip3 install --user -U "git+git://github.com/byro/byro.git@main#egg=byro&subdirectory=src"
Collecting byro
  Cloning git://github.com/byro/byro.git (to revision main) to /tmp/pip-install-dr2sqbma/byro_da7ed145871645288b1d2feb0000dfba
  Running command git clone --filter=blob:none -q git://github.com/byro/byro.git /tmp/pip-install-dr2sqbma/byro_da7ed145871645288b1d2feb0000dfba
  WARNING: Did not find branch or tag 'main', assuming revision or ref.
  Running command git checkout -q main
  error: pathspec 'main' did not match any file(s) known to git
WARNING: Discarding git+git://github.com/byro/byro.git@main#egg=byro&subdirectory=src. Command errored out with exit status 1: git checkout -q main Check the logs for full command output.
ERROR: Could not find a version that satisfies the requirement byro (unavailable) (from versions: 0.0.1)
ERROR: No matching distribution found for byro (unavailable)
```

Results after this change:

```
$ pip3 install --user -U "git+git://github.com/byro/byro.git@master#egg=byro&subdirectory=src"
Collecting byro
  Cloning git://github.com/byro/byro.git (to revision master) to /tmp/pip-install-4pz1vv4r/byro_9e4cfe8777f748c6b7b9b6e996a612af
  Running command git clone --filter=blob:none -q git://github.com/byro/byro.git /tmp/pip-install-4pz1vv4r/byro_9e4cfe8777f748c6b7b9b6e996a612af
  Resolved git://github.com/byro/byro.git to commit 26dac998dfc2408224ebddc008f3df85f88f4a1a
  Preparing metadata (setup.py) ... done
...
```