### PR TITLE
Updated: python-version to be parsed correctly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/cache@v2.1.7
         with:
           path: ~/.cache/pip
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/cache@v2.1.7
         with:
           path: ~/.cache/pip

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/cache@v2.1.7
         with:
           path: ~/.cache/pip
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/cache@v2.1.7
         with:
           path: ~/.cache/pip
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/cache@v2.1.7
         with:
           path: ~/.cache/pip
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/cache@v2.1.7
         with:
           path: ~/.cache/pip
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2.3.1
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - uses: actions/cache@v2.1.7
         with:
           path: ~/.cache/pip


### PR DESCRIPTION
Updated the python-version to be interpreted correctly. Currently it get's interpreted as 3.1 instead of 3.10. Therefore the quotes (@rixx)