### PR TITLE
Make postgresql backend the explicit default to restore old behavior

### DIFF
--- a/docs/administrator/configuration.rst
+++ b/docs/administrator/configuration.rst
@@ -130,7 +130,7 @@ The database section
 
 - The database engine.
 - **Environment variable:** ``BYRO_DB_ENGINE``
-- **Default:** ``''`` – by default it falls back to the PostgreSQL backend
+- **Default:** ``'postgresql'`` – by default it falls back to the PostgreSQL backend
 - **Possible values:** ``postgresql``, ``mysql``, ``sqlite3``, ``oracle``
 
 The mail section

--- a/src/byro/common/settings/config.py
+++ b/src/byro/common/settings/config.py
@@ -26,7 +26,7 @@ CONFIG = {
         "password": {"default": "", "env": os.getenv("BYRO_DB_PASS")},
         "host": {"default": "", "env": os.getenv("BYRO_DB_HOST")},
         "port": {"default": "", "env": os.getenv("BYRO_DB_PORT")},
-        "engine": {"default": "", "env": os.getenv("BYRO_DB_ENGINE")},
+        "engine": {"default": "postgresql", "env": os.getenv("BYRO_DB_ENGINE")},
     },
     "mail": {
         "from": {"default": "admin@localhost", "env": os.getenv("BYRO_MAIL_FROM")},


### PR DESCRIPTION
I noticed that the test failed because I added the engine setting to src/byro/common/settings/config.py. This should fix it because when left out the db backend will be set to postgresql again.