### PR TITLE
Updated container names as the naming scheme has changed

### DIFF
--- a/production/setup.sh
+++ b/production/setup.sh
@@ -43,7 +43,7 @@ EOF
     cp "$DIR/byro.example.cfg" "$CONFIG"
     
     start_db
-    IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' byro_db_1)"
+    IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' byro-db-1)"
     # BSD sed needs a suffix for -i, GNU doesn't care
     sed -i.bak "s/MAIL_HOST/$IP/" "$CONFIG"
     rm -f "$CONFIG.bak"
@@ -139,7 +139,7 @@ manage)
     manage "$@"
     ;;
 db)
-    docker exec -it byro_db_1 psql -U byro
+    docker exec -it byro-db-1 psql -U byro
     ;;
 help|--help|-h|h)
     cat <<EOF


### PR DESCRIPTION
Currently, the setup.sh script is failing as the naming scheme for docker containers has changed. This PR fixes the issue

```
[+] Running 9/9
 ⠿ db Pulled                                                                                                                                           6.9s
   ⠿ 530afca65e2e Already exists                                                                                                                       0.0s
   ⠿ 915bf02ec410 Already exists                                                                                                                       0.0s
   ⠿ b026a0cf3c97 Already exists                                                                                                                       0.0s
   ⠿ 88659e2107f6 Pull complete                                                                                                                        3.9s
   ⠿ 33960a1e9871 Pull complete                                                                                                                        4.0s
   ⠿ b9bbc907277f Pull complete                                                                                                                        4.0s
   ⠿ 7e545c6230ec Pull complete                                                                                                                        4.1s
   ⠿ ba5428d6e942 Pull complete                                                                                                                        4.1s
[+] Running 2/2
 ⠿ Network byro_default  Created                                                                                                                       0.1s
 ⠿ Container byro-db-1   Started                                                                                                                       0.6s
Error: No such object: byro_db_1
```