### PR TITLE
Fix for Dockerfile smell DL3003

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -14,8 +14,9 @@ RUN mkdir -p /byro && chown uid1000: /byro
 
 ADD . /byro
 ADD byro.docker.cfg /byro/byro.cfg
-RUN cd /byro && pip3 install -e . && pip3 install gunicorn
-RUN cd /byro && /bin/zsh install_local_plugins.sh
+WORKDIR /byro 
+RUN  pip3 install -e . && pip3 install gunicorn
+RUN  /bin/zsh install_local_plugins.sh
 
 CMD ["runserver", "0.0.0.0:8020"]
 


### PR DESCRIPTION
Hi!
The Dockerfile placed at "src/Dockerfile" contains the best practice violation [DL3003](https://github.com/hadolint/hadolint/wiki/DL3003) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3003 occurs if the pattern `RUN cd ...` is used to change directories instead of the dedicated WORKDIR instruction.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the pattern `RUN cd ...` is replaced with the equivalent WORKDIR instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance