### PR TITLE
Fix django 4.2 update implications

### DIFF
--- a/docs/developer/plugins/member-data.rst
+++ b/docs/developer/plugins/member-data.rst
@@ -57,7 +57,7 @@ and register it in your ``signals.py``::
 
    from django.dispatch import receiver
    from django.urls import reverse
-   from django.utils.translation import ugettext_lazy as _
+   from django.utils.translation import text_lazy as _
 
    from byro.office.signals import member_view
 
@@ -76,7 +76,7 @@ add a general newsletter view to the sidebar::
 
    from django.dispatch import receiver
    from django.urls import reverse
-   from django.utils.translation import ugettext_lazy as _
+   from django.utils.translation import gettext_lazy as _
 
    from byro.office.signals import nav_event
 
@@ -100,7 +100,7 @@ related model. If the model class inherits from ``ByroConfiguration`` and ends
 in ``Configuration``, it will be automatically added to the settings page::
 
    from django.db import models
-   from django.utils.translation import ugettext_lazy as _
+   from django.utils.translation import gettext_lazy as _
 
    from byro.common.models.configuration import ByroConfiguration
 

--- a/docs/developer/plugins/plugins.rst
+++ b/docs/developer/plugins/plugins.rst
@@ -49,7 +49,7 @@ description        string               A more verbose description of what your 
 A working example would be::
 
     from django.apps import AppConfig
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 
 
     class IRCApp(AppConfig):

--- a/src/setup.py
+++ b/src/setup.py
@@ -53,7 +53,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.2",
         "Intended Audience :: Developers",
         "Intended Audience :: Other Audience",
         "License :: OSI Approved",


### PR DESCRIPTION
Template was theoretically deprecated since django2.2 and all plugins will break the whole instance if not updated :)