### PR TITLE
HOTFIX: plugin installation fails

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -16,7 +16,7 @@ ADD . /byro
 ADD byro.docker.cfg /byro/byro.cfg
 WORKDIR /byro 
 RUN   pip install --upgrade pip && pip3 install -e . && pip3 install gunicorn
-RUN  /bin/zsh install_local_plugins.sh
+RUN   pip install setuptools && /bin/zsh install_local_plugins.sh
 
 CMD ["runserver", "0.0.0.0:8020"]
 

--- a/src/install_local_plugins.sh
+++ b/src/install_local_plugins.sh
@@ -8,7 +8,5 @@ fi
 for plugin in local/*(N); do  # this is a nullglob
   echo "installing $plugin"
 
-  cd $plugin
-  python setup.py develop
-  cd -
+  pip install -e $plugin --no-build-isolation
 done


### PR DESCRIPTION
`setup.py develop` does not work anymore as distutils was removed in python3.12, so this mitigates the issue by using `pip install -e --no-build-isolation`.
This is a severe issue, again caused by an dependabot update, without checking if a plugin works like before. There should be some test, like install fints and check if the plugin is accessible.
Spend the evening on this, though I crashed our installation by some misconfiguration...