### PR TITLE
Feature: Deactivate user by setting invalid password

### DIFF
--- a/src/byro/locale/de/LC_MESSAGES/django.po
+++ b/src/byro/locale/de/LC_MESSAGES/django.po
@@ -1669,6 +1669,35 @@ msgstr "Benutzer hinzufügen …"
 msgid "User"
 msgstr "Benutzer"
 
+#: byro/office/templates/office/user/detail.html:8
+msgid "Password disabled – user cannot log in with a password"
+msgstr "Passwort deaktiviert – Benutzer kann sich nicht mit einem Passwort anmelden"
+
+#: byro/office/templates/office/user/detail.html:9
+#: byro/office/templates/office/user/list.html:30
+msgid "Password disabled"
+msgstr "Passwort deaktiviert"
+
+#: byro/office/templates/office/user/detail.html:28
+msgid ""
+"Disable this user's password? They will no longer be able to log in with a "
+"password."
+msgstr ""
+"Passwort dieses Benutzers deaktivieren? Der Benutzer kann sich danach nicht "
+"mehr mit einem Passwort anmelden."
+
+#: byro/office/templates/office/user/detail.html:29
+msgid "Disable password"
+msgstr "Passwort deaktivieren"
+
+#: byro/office/templates/office/user/detail.html:35
+msgid ""
+"This user's password is disabled. Set a new password above to re-enable "
+"password login."
+msgstr ""
+"Das Passwort dieses Benutzers ist deaktiviert. Oben ein neues Passwort "
+"setzen, um die Passwortanmeldung wieder zu aktivieren."
+
 #: byro/office/templates/office/user/list.html:10
 msgid "Add new user"
 msgstr "Neuen Benutzer hinzufügen"
@@ -1992,6 +2021,14 @@ msgstr "Der Import konnte nicht verarbeitet werden: "
 #: byro/office/views/users.py:11
 msgid "Password"
 msgstr "Passwort"
+
+#: byro/office/views/users.py:89
+msgid "You cannot disable your own password."
+msgstr "Du kannst dein eigenes Passwort nicht deaktivieren."
+
+#: byro/office/views/users.py:99
+msgid "The user's password has been disabled."
+msgstr "Das Passwort des Benutzers wurde deaktiviert."
 
 #: byro/plugins/profile/models.py:13
 msgid "Nick"

--- a/src/byro/locale/de/LC_MESSAGES/django.po
+++ b/src/byro/locale/de/LC_MESSAGES/django.po
@@ -1679,12 +1679,8 @@ msgid "Password disabled"
 msgstr "Passwort deaktiviert"
 
 #: byro/office/templates/office/user/detail.html:28
-msgid ""
-"Disable this user's password? They will no longer be able to log in with a "
-"password."
-msgstr ""
-"Passwort dieses Benutzers deaktivieren? Der Benutzer kann sich danach nicht "
-"mehr mit einem Passwort anmelden."
+msgid "Disable password for this user? They will no longer be able to log in with a password."
+msgstr "Passwort dieses Benutzers deaktivieren? Der Benutzer kann sich danach nicht mehr mit einem Passwort anmelden."
 
 #: byro/office/templates/office/user/detail.html:29
 msgid "Disable password"

--- a/src/byro/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/byro/locale/pt_BR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: byro\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-04 14:58-0300\n"
+"POT-Creation-Date: 2026-03-21 20:17+0000\n"
 "Language: pt-br\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1675,6 +1675,34 @@ msgstr "Adicionar usuária …"
 msgid "User"
 msgstr "Usuária"
 
+#: byro/office/templates/office/user/detail.html:8
+msgid "Password disabled – user cannot log in with a password"
+msgstr "Senha desativada – usuário não pode entrar com senha"
+
+#: byro/office/templates/office/user/detail.html:9
+#: byro/office/templates/office/user/list.html:30
+msgid "Password disabled"
+msgstr "Senha desativada"
+
+#: byro/office/templates/office/user/detail.html:28
+msgid ""
+"Disable this user's password? They will no longer be able to log in with a "
+"password."
+msgstr ""
+"Desativar a senha desta pessoa? Ela não poderá mais entrar com senha."
+
+#: byro/office/templates/office/user/detail.html:29
+msgid "Disable password"
+msgstr "Desativar senha"
+
+#: byro/office/templates/office/user/detail.html:35
+msgid ""
+"This user's password is disabled. Set a new password above to re-enable "
+"password login."
+msgstr ""
+"A senha desta pessoa está desativada. Defina uma nova senha acima para "
+"reativar o login com senha."
+
 #: byro/office/templates/office/user/list.html:10
 msgid "Add new user"
 msgstr "Adicionar nova usuária"
@@ -1985,6 +2013,14 @@ msgstr "O upload não pôde ser processado: "
 #: byro/office/views/users.py:11
 msgid "Password"
 msgstr "Senha"
+
+#: byro/office/views/users.py:89
+msgid "You cannot disable your own password."
+msgstr "Você não pode desativar sua própria senha."
+
+#: byro/office/views/users.py:99
+msgid "The user's password has been disabled."
+msgstr "A senha da pessoa usuária foi desativada."
 
 #: byro/plugins/profile/models.py:13
 msgid "Nick"

--- a/src/byro/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/byro/locale/pt_BR/LC_MESSAGES/django.po
@@ -1685,11 +1685,8 @@ msgid "Password disabled"
 msgstr "Senha desativada"
 
 #: byro/office/templates/office/user/detail.html:28
-msgid ""
-"Disable this user's password? They will no longer be able to log in with a "
-"password."
-msgstr ""
-"Desativar a senha desta pessoa? Ela não poderá mais entrar com senha."
+msgid "Disable password for this user? They will no longer be able to log in with a password."
+msgstr "Desativar a senha desta pessoa? Ela não poderá mais entrar com senha."
 
 #: byro/office/templates/office/user/detail.html:29
 msgid "Disable password"

--- a/src/byro/members/models.py
+++ b/src/byro/members/models.py
@@ -705,9 +705,8 @@ class Membership(Auditable, models.Model, LogTargetMixin):
         if not end:
             try:
                 end = _now.replace(day=start.day).date()
-            except (
-                ValueError
-            ):  # membership.start.day is not a valid date in our month, we'll use the last date instead
+            except ValueError:
+                # membership.start.day is not a valid date in our month, use last date instead
                 end = (_now + relativedelta(day=1, months=1, days=-1)).date()
         date = start
         while date <= end:

--- a/src/byro/members/models.py
+++ b/src/byro/members/models.py
@@ -324,12 +324,11 @@ class Member(Auditable, models.Model, LogTargetMixin):
         )
         if asset_start:
             credits = credits.filter(transaction__value_datetime__gte=asset_start)
-        liability = (
-            debits.aggregate(liability=models.Sum("amount"))["liability"]
-            or Decimal("0.00")
-        )
-        asset = (
-            credits.aggregate(asset=models.Sum("amount"))["asset"] or Decimal("0.00")
+        liability = debits.aggregate(liability=models.Sum("amount"))[
+            "liability"
+        ] or Decimal("0.00")
+        asset = credits.aggregate(asset=models.Sum("amount"))["asset"] or Decimal(
+            "0.00"
         )
         return asset - liability
 
@@ -557,7 +556,9 @@ class Member(Auditable, models.Model, LogTargetMixin):
             transaction__reversed_by__isnull=True,
         )
         if _from is not None:
-            stray_liabilities_qs = stray_liabilities_qs.filter(transaction__value_datetime__gte=_from)
+            stray_liabilities_qs = stray_liabilities_qs.filter(
+                transaction__value_datetime__gte=_from
+            )
         if membership_ranges:
             stray_liabilities_qs = stray_liabilities_qs.exclude(date_range_q)
         stray_liabilities_qs = stray_liabilities_qs.prefetch_related("transaction")

--- a/src/byro/members/models.py
+++ b/src/byro/members/models.py
@@ -324,11 +324,12 @@ class Member(Auditable, models.Model, LogTargetMixin):
         )
         if asset_start:
             credits = credits.filter(transaction__value_datetime__gte=asset_start)
-        liability = debits.aggregate(liability=models.Sum("amount"))[
-            "liability"
-        ] or Decimal("0.00")
-        asset = credits.aggregate(asset=models.Sum("amount"))["asset"] or Decimal(
-            "0.00"
+        liability = (
+            debits.aggregate(liability=models.Sum("amount"))["liability"]
+            or Decimal("0.00")
+        )
+        asset = (
+            credits.aggregate(asset=models.Sum("amount"))["asset"] or Decimal("0.00")
         )
         return asset - liability
 

--- a/src/byro/office/templates/office/user/detail.html
+++ b/src/byro/office/templates/office/user/detail.html
@@ -4,6 +4,11 @@
 
 {% block headline %}{% trans "User" %}
     {% if user.last_name %}{{user.last_name}} ({{user.username}}){% else %}{{user.username}}{% endif %}
+    {% if not user.has_usable_password %}
+        <span class="badge badge-warning ml-2" title="{% trans "Password disabled – user cannot log in with a password" %}">
+            <span class="fa fa-lock"></span> {% trans "Password disabled" %}
+        </span>
+    {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -13,4 +18,22 @@
         {% bootstrap_form form layout='horizontal' %}
         <button class="btn btn-success" type="submit">{% trans "Save" %}</button>
     </form>
+
+    {% if user.pk != request.user.pk %}
+        <hr>
+        {% if user.has_usable_password %}
+            <form method="post" action="{% url 'office:settings.users.disable-password' pk=user.pk %}">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-danger"
+                    onclick="return confirm('{% trans "Disable this user's password? They will no longer be able to log in with a password." %}')">
+                    <span class="fa fa-lock"></span> {% trans "Disable password" %}
+                </button>
+            </form>
+        {% else %}
+            <p class="text-muted">
+                <span class="fa fa-lock"></span>
+                {% trans "This user's password is disabled. Set a new password above to re-enable password login." %}
+            </p>
+        {% endif %}
+    {% endif %}
 {% endblock %}

--- a/src/byro/office/templates/office/user/detail.html
+++ b/src/byro/office/templates/office/user/detail.html
@@ -25,7 +25,7 @@
             <form method="post" action="{% url 'office:settings.users.disable-password' pk=user.pk %}">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-danger"
-                    onclick="return confirm('{% trans "Disable this user's password? They will no longer be able to log in with a password." %}')">
+                    onclick="return confirm('{% trans "Disable password for this user? They will no longer be able to log in with a password." |escapejs %}')">
                     <span class="fa fa-lock"></span> {% trans "Disable password" %}
                 </button>
             </form>

--- a/src/byro/office/templates/office/user/list.html
+++ b/src/byro/office/templates/office/user/list.html
@@ -26,6 +26,9 @@
                         {% if not user.is_active %}
                             <span class="fa fa-times-circle" title="{% trans "User deactivated" %}"></span><span class="sr-only">{% trans "User deactivated" %}</span>
                         {% endif %}
+                        {% if not user.has_usable_password %}
+                            <span class="fa fa-lock" title="{% trans "Password disabled" %}"></span><span class="sr-only">{% trans "Password disabled" %}</span>
+                        {% endif %}
                         {% if user.is_superuser %}
                             <span class="fa fa-wrench" title="{% trans "Superuser" %}"></span><span class="sr-only">{% trans "Superuser" %}</span>
                         {% else %}

--- a/src/byro/office/urls.py
+++ b/src/byro/office/urls.py
@@ -37,6 +37,11 @@ urlpatterns = [
         users.UserDetailView.as_view(),
         name="settings.users.detail",
     ),
+    path(
+        "settings/users/<int:pk>/disable-password",
+        users.UserPasswordDisableView.as_view(),
+        name="settings.users.disable-password",
+    ),
     path("settings", settings.ConfigurationView.as_view(), name="settings.base"),
     path("", dashboard.DashboardView.as_view(), name="dashboard"),
     path(

--- a/src/byro/office/views/users.py
+++ b/src/byro/office/views/users.py
@@ -1,8 +1,10 @@
 from django import forms
+from django.contrib import messages
 from django.contrib.auth.models import User
+from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import DetailView, FormView, ListView, UpdateView
+from django.views.generic import DetailView, FormView, ListView, UpdateView, View
 
 from byro.common.models import LogEntry
 
@@ -79,6 +81,23 @@ class UserDetailView(UpdateView):
 
     def get_success_url(self):
         return reverse("office:settings.users.detail", kwargs={"pk": self.kwargs["pk"]})
+
+
+class UserPasswordDisableView(View):
+    def post(self, request, pk, *args, **kwargs):
+        if request.user.pk == pk:
+            messages.error(request, _("You cannot disable your own password."))
+            return redirect(reverse("office:settings.users.detail", kwargs={"pk": pk}))
+        user = get_object_or_404(User, pk=pk)
+        user.set_unusable_password()
+        user.save()
+        LogEntry.objects.create(
+            content_object=user,
+            user=request.user,
+            action_type="byro.common.user.password_disabled",
+        )
+        messages.success(request, _("The user's password has been disabled."))
+        return redirect(reverse("office:settings.users.detail", kwargs={"pk": pk}))
 
 
 # FIXME No implemented yet


### PR DESCRIPTION
Closes #428

Wording chosen to not suggest, that the account is inactive per se, as login might be still available via OIDC if configured and the user is allowed via groups.
Creates (easy resolvable) merge conflict with OIDC branch as the po files are updated in the same place as well as users.py.