### PR TITLE
Move balance refresh to thread

### DIFF
--- a/src/byro/locale/de/LC_MESSAGES/django.po
+++ b/src/byro/locale/de/LC_MESSAGES/django.po
@@ -1402,6 +1402,18 @@ msgstr "Zahl"
 msgid "Refresh"
 msgstr "Aktualisieren"
 
+#: byro/office/templates/office/member/list.html
+msgid "Refreshing…"
+msgstr "Wird aktualisiert…"
+
+#: byro/office/views/members.py
+msgid "Balance refresh is already running in the background."
+msgstr "Kontenstandaktualisierung läuft bereits im Hintergrund."
+
+#: byro/office/views/members.py
+msgid "Balance refresh has been started in the background."
+msgstr "Kontenstandaktualisierung wurde im Hintergrund gestartet."
+
 #: byro/office/templates/office/member/list_export.html:9
 msgid ""
 "Select the export format and fields to be exported, then press 'Export'."

--- a/src/byro/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/byro/locale/pt_BR/LC_MESSAGES/django.po
@@ -1408,6 +1408,18 @@ msgstr "Número"
 msgid "Refresh"
 msgstr "Atualizar"
 
+#: byro/office/templates/office/member/list.html
+msgid "Refreshing…"
+msgstr "Atualizando…"
+
+#: byro/office/views/members.py
+msgid "Balance refresh is already running in the background."
+msgstr "A atualização de saldo já está em execução em segundo plano."
+
+#: byro/office/views/members.py
+msgid "Balance refresh has been started in the background."
+msgstr "A atualização de saldo foi iniciada em segundo plano."
+
 #: byro/office/templates/office/member/list_export.html:9
 msgid ""
 "Select the export format and fields to be exported, then press 'Export'."

--- a/src/byro/office/templates/office/member/list.html
+++ b/src/byro/office/templates/office/member/list.html
@@ -45,8 +45,9 @@
                     <th>{% trans "Number" %}</th>
                     <th>{% trans "Name" %}</th>
                     <th>{% trans "Balance" %}
-                        <button type="submit" class="btn-success btn-small">
-                            <span class="fa fa-refresh"></span> {% trans "Refresh" %}
+                        <button type="submit" class="btn-success btn-small" {% if balance_refresh_running %}disabled{% endif %}>
+                            <span class="fa fa-refresh{% if balance_refresh_running %} fa-spin{% endif %}"></span>
+                            {% if balance_refresh_running %}{% trans "Refreshing…" %}{% else %}{% trans "Refresh" %}{% endif %}
                         </button>
                     </th>
                 </tr>

--- a/src/byro/office/views/members.py
+++ b/src/byro/office/views/members.py
@@ -104,6 +104,22 @@ class MemberListMixin:
         return qs.order_by("-id").distinct()
 
 
+_BALANCE_REFRESH_LOCK = "byro_balance_refresh_running"
+_BALANCE_REFRESH_LOCK_TIMEOUT = 60 * 60  # 1 hour safety expiry
+
+
+def _run_balance_refresh():
+    from django.core.cache import cache
+
+    if not cache.add(_BALANCE_REFRESH_LOCK, True, _BALANCE_REFRESH_LOCK_TIMEOUT):
+        return
+    try:
+        for member in Member.objects.all():
+            member.update_liabilites()
+    finally:
+        cache.delete(_BALANCE_REFRESH_LOCK)
+
+
 class MemberListView(MemberListMixin, ListView):
     template_name = "office/member/list.html"
     context_object_name = "members"
@@ -115,9 +131,29 @@ class MemberListView(MemberListMixin, ListView):
         _filter = self.request.GET.get("filter", "active")
         return self.get_members_queryset(search, _filter)
 
+    def get_context_data(self, **kwargs):
+        from django.core.cache import cache
+
+        context = super().get_context_data(**kwargs)
+        context["balance_refresh_running"] = bool(cache.get(_BALANCE_REFRESH_LOCK))
+        return context
+
     def post(self, request, *args, **kwargs):
-        for member in Member.objects.all():
-            member.update_liabilites()
+        from django.core.cache import cache
+
+        if cache.get(_BALANCE_REFRESH_LOCK):
+            messages.info(
+                request,
+                _("Balance refresh is already running in the background."),
+            )
+        else:
+            import threading
+
+            threading.Thread(target=_run_balance_refresh, daemon=True).start()
+            messages.success(
+                request,
+                _("Balance refresh has been started in the background."),
+            )
         return redirect(request.path)
 
 


### PR DESCRIPTION
- django cache makes sure, only one instance is running, so no more duplicate bookings if refresh is hit accidentally twice
- moved to background task, so balance refresh won't get interrupted, if the http request is cancelled or times out, which might happend depending on hardware/load/members
- fixes #427 🎉 